### PR TITLE
add share link

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,30 +31,34 @@
     </div>
   </section>
 
+  <section id="showingShared" style="display: none">
+    <h2>Showing shared marks. <a href="./">Edit my marks.</a></h2>
+  </section>
+
   <section id="l5">
     <h2>Level 5</h2>
     <div class="module">
-      <input id="l5unit1" type="text" tabindex="1" placeholder="module name">
+      <input id="l5name1" type="text" tabindex="1" placeholder="module name">
       <input id="l5mark1" type="number" value="40" min="0" max="100" tabindex="11" placeholder="0">
     </div>
     <div class="module">
-      <input id="l5unit2" type="text" tabindex="2" placeholder="module name">
+      <input id="l5name2" type="text" tabindex="2" placeholder="module name">
       <input id="l5mark2" type="number" value="40" min="0" max="100" tabindex="12" placeholder="0">
     </div>
     <div class="module">
-      <input id="l5unit3" type="text" tabindex="3" placeholder="module name">
+      <input id="l5name3" type="text" tabindex="3" placeholder="module name">
       <input id="l5mark3" type="number" value="40" min="0" max="100" tabindex="13" placeholder="0">
     </div>
     <div class="module">
-      <input id="l5unit4" type="text" tabindex="4" placeholder="module name">
+      <input id="l5name4" type="text" tabindex="4" placeholder="module name">
       <input id="l5mark4" type="number" value="40" min="0" max="100" tabindex="14" placeholder="0">
     </div>
     <div class="module">
-      <input id="l5unit5" type="text" tabindex="5" placeholder="module name">
+      <input id="l5name5" type="text" tabindex="5" placeholder="module name">
       <input id="l5mark5" type="number" value="40" min="0" max="100" tabindex="15" placeholder="0">
     </div>
     <div class="module">
-      <input id="l5unit6" type="text" tabindex="6" placeholder="module name">
+      <input id="l5name6" type="text" tabindex="6" placeholder="module name">
       <input id="l5mark6" type="number" value="40" min="0" max="100" tabindex="16" placeholder="0">
     </div>
   </section>
@@ -63,25 +67,32 @@
   <section id="l6">
     <h2>Level 6</h2>
     <div class="module">
-      <input id="l6unit1" type="text" tabindex="7" placeholder="module name">
+      <input id="l6name1" type="text" tabindex="7" placeholder="module name">
       <input id="l6mark1" type="number" tabindex="17" value="40" min="0" max="100" placeholder="0">
     </div>
     <div class="module">
-      <input id="l6unit2" type="text" tabindex="8" placeholder="module name">
+      <input id="l6name2" type="text" tabindex="8" placeholder="module name">
       <input id="l6mark2" type="number" tabindex="18" value="40" min="0" max="100" placeholder="0">
     </div>
     <div class="module">
-      <input id="l6unit3" type="text" tabindex="9" placeholder="module name">
+      <input id="l6name3" type="text" tabindex="9" placeholder="module name">
       <input id="l6mark3" type="number" tabindex="19" value="40" min="0" max="100" placeholder="0">
     </div>
     <div class="module">
-      <input id="l6unit4" type="text" tabindex="10" placeholder="module name">
+      <input id="l6name4" type="text" tabindex="10" placeholder="module name">
       <input id="l6mark4" type="number" tabindex="20" value="40" min="0" max="100" placeholder="0">
     </div>
     <div class="module">
       <span>Project</span>
-      <input id="fyp" type="number" value="40" min=0 max=100 placeholder="0">
+      <input id="fyp" type="number" tabindex="21" value="40" min=0 max=100 placeholder="0">
     </div>
+  </section>
+
+  <section id="share">
+    <h2>Share my marks</h2>
+    <p>Send the link below to your friends and parents so they can see your expected grade.
+      They will see a copy of all the data entered above.</p>
+    <input id="shareLink" type="text" tabindex="22">
   </section>
 
 </main>

--- a/style.css
+++ b/style.css
@@ -82,6 +82,7 @@ input:focus {
   display: flex;
   flex-direction: row;
   justify-content: space-around;
+  flex-wrap: wrap;
 }
 
 #results * {
@@ -113,6 +114,17 @@ input:focus {
   transform: translateX(50%) rotate(45deg);
   transform-origin: top center;
   text-decoration: none;
+}
+
+#share {
+  display: flex;
+  flex-direction: column;
+}
+#share p { margin-top: 0; }
+#share input { font-size: 1rem; }
+#showingShared {
+  flex: 0 0 100%;
+  text-align: center;
 }
 
 @media screen and (min-width: 70rem) {


### PR DESCRIPTION
fix #3 

When showing shared marks, mark editing is disabled and local storage is ignored, so a user doesn't accidentally overwrite their marks by looking at someone else's.

We may want a way of importing shared marks, possibly with a warning if we'd be overwriting our stored marks, but let's let the users suggest what exactly they want.

This will want to be incorporated into `big-pr` if @ear1grey likes it.