### PR TITLE
Added Integrated Masters calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ University of Portsmouth calculates final degree classification in three ways, a
 
 If you're a student, it may be interesting to see how your current/predicted grades might affect your final classification.  Remember too, that it's not all about the grades - they may show capability, but they can never reflect who you are or how well you'll fit & contribute to any team.
 
-[Try it now](https://portsoc.github.io/dcalc/)
+[Try it now (https://portsoc.github.io/dcalc/)](https://portsoc.github.io/dcalc/)
 
 Please add suggestions & bug reports to the [issue list](https://github.com/portsoc/dcalc/issues).
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 <link rel="manifest" href="manifest.json">
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#621360" />
+<link rel="apple-touch-icon" href="/img/192.png" />
 
 <nav id="source">
   <a href="https://github.com/portsoc/dcalc">Source</a>
@@ -17,8 +19,8 @@
 
   <section id="results">
     <div>
-        <h2>Indication:</h2>
-        <p id="finalClassification">not enough data</span>.</p>
+      <h2>Indication:</h2>
+      <p id="finalClassification">not enough data</span>.</p>
     </div>
     <div>
       <h2>GPA:</h2>
@@ -96,7 +98,7 @@
       <input id="shareLink" type="text" tabindex="22" readonly>
       <button id="copy" tabindex="23">Copy</button>
     </div>
-</section>
+  </section>
 
 </main>
 

--- a/js/meng_rules.js
+++ b/js/meng_rules.js
@@ -97,14 +97,3 @@ function toClassificationMeng(mark) {
   if (mark < 70) return 'with Merit';
   return 'with Distinction';
 }
-
-
-
-/* for testing
-
-const marks = {
-    l5: [45, 56, 67, 78, 89, 90],
-    l6: [56, 67, 78, 89],
-    fyp: 68,
-}
-*/

--- a/js/rules.js
+++ b/js/rules.js
@@ -75,33 +75,36 @@ function gradeToGPA(num) {
 }
 
 function gpa(marks) {
-  const weightedl5mean = rawmean(marks.prepared.l5gpa) * 0.4;
-  const weightedl6mean = rawmean(marks.prepared.l6gpa) * 0.6;
+  const weightedl5mean = mean(marks.prepared.l5gpa) * 0.4;
+  const weightedl6mean = mean(marks.prepared.l6gpa) * 0.6;
   return Number( weightedl5mean + weightedl6mean ).toFixed(2);
 }
 
 function ruleA(marks) {
   const l5mean = mean(marks.prepared.l5);
   const l6mean = mean(marks.prepared.l6);
-  return Math.round(l5mean * 0.4 + l6mean * 0.6);
+  return roundDown(l5mean * 0.4 + l6mean * 0.6);
 }
 
 function ruleB(marks) {
-  return mean(marks.prepared.l6);
+  return roundDown(mean(marks.prepared.l6));
 }
 
 function ruleC(marks) {
   const allMarks = marks.prepared.l5.concat(marks.prepared.l6);
   allMarks.sort(reverseNumericalComparison);
-  return Math.round(allMarks[allMarks.length / 2]);
-}
-
-function rawmean(array) {
-  return array.reduce( (a,b) => a+b ) / array.length;
+  return roundDown(allMarks[allMarks.length / 2]);
 }
 
 function mean(array) {
-  return Math.round(rawmean(array));
+  return array.reduce( (a,b) => a+b ) / array.length;
+}
+
+function roundDown(num, digits = 2) {
+  const str = String(num);
+  const [whole, decimal] = str.split('.');
+  const padded = (decimal || '00').padEnd(digits, '0');
+  return whole + '.' + padded.substring(0, 2);
 }
 
 function toClassification(mark) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,6 @@
 {
     "name": "Portsmouth Degree Calculator",
+    "short_name": "Portsmouth Degree Calculator",
     "icons": [
         {
             "purpose": "maskable",
@@ -8,7 +9,7 @@
             "sizes": "512x512"
         },
         {
-            "purpose": "maskable",
+            "purpose": "any maskable",
             "src": "./img/192.png",
             "type": "image/png",
             "sizes": "192x192"
@@ -18,5 +19,5 @@
     "start_url": "./index.html",
     "background_color": "#FFF",
     "scope": "/",
-    "theme_color": "#00a0ff"
+    "theme_color": "#621360"
 }

--- a/style.css
+++ b/style.css
@@ -5,6 +5,17 @@
   --hibg: #0076A6;
   --hifg: #000;
 }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #000;
+    --fg: #BBB;
+    --hifg: #40B;
+    --hibg: #DDD;
+  }
+}
+
+
 html {
   font-family: "Aero", "Calibri", sans-serif;
   background: var(--bg);
@@ -164,14 +175,5 @@ input:focus {
 
   #results {
     width: 100%;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #000;
-    --fg: #BBB;
-    --hifg: #40B;
-    --hibg: #DDD;
   }
 }

--- a/style.css
+++ b/style.css
@@ -170,8 +170,8 @@ input:focus {
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: #000;
-    --fg: #777;
+    --fg: #BBB;
     --hifg: #40B;
-    --hibg: #CCC;
+    --hibg: #DDD;
   }
 }


### PR DESCRIPTION
### What's Changed:
Added an integrated masters calculator. There are now radio buttons in the top left. If BSc is selected, the calculator works as before. If MEng is selected, another set of inputs is added for the 4th year, and the rules and Indications are changed to reflect what MEng classification the student would receive.

The rules for calculating MEng classification are found below, in section 5.4.5.7:
http://regulations.docstore.port.ac.uk/ExamRegs9BoardofExaminers.pdf

-Josh (up847988)