### PR TITLE
Bring source anchor tag to front

### DIFF
--- a/style.css
+++ b/style.css
@@ -189,7 +189,6 @@ input:focus {
   top: 0;
   height: 10em;
   overflow: hidden;
-  z-index: -1;
 }
 
 #source a {


### PR DESCRIPTION
**Overview**
When the live site (https://portsoc.github.io/dcalc/) is visited on Firefox or Chrome (tested using the latest version of each), portions of the "Source" button are hidden behind the `<h1>` element. This PR removes the erroneous `z-index` property, bringing the view source button back on top.

**Testing**
This PR has been tested in the latest versions of Chrome, Firefox and Safari (as of writing).

Interestingly, the live site works fine on Safari but does not work on Chrome or Firefox.

**Screenshot**
In the below screenshot, I've added a `background: salmon;` property to the `<header>`. Any area coloured in salmon prevents the source link from being clicked.
![image](https://user-images.githubusercontent.com/35199256/136056432-64a41c26-f703-4118-9d38-77dfb542dc65.png)

With the property removed, the source link is brought back on top.
![image](https://user-images.githubusercontent.com/35199256/136057075-7540b630-ca80-49b8-90cb-2b3e42677111.png)
