### PR TITLE
Correct width on narrow displays

### DIFF
--- a/style.css
+++ b/style.css
@@ -79,7 +79,7 @@ header {
 
 section {
   display: inline-block;
-  width: 30rem;
+  width: 100%;
 }
 
 /*********************************************

--- a/style.css
+++ b/style.css
@@ -17,6 +17,10 @@
   --wide-align: center;
 }
 
+section {
+    width: 100%;
+}
+
 /*********************************************
  * WIDE LAYOUT
  *********************************************/
@@ -26,6 +30,10 @@
     --header-align: center;
     --wide-direction: row;
     --wide-align: start;
+  }
+
+  section {
+      width: 30rem;
   }
 }
 
@@ -79,7 +87,6 @@ header {
 
 section {
   display: inline-block;
-  width: 100%;
 }
 
 /*********************************************


### PR DESCRIPTION
**Overview**
On the live site, narrow displays cause the header to look narrower than the rest of the content. This PR fixes that behaviour, whilst ensuring compatability on wider displays.

**Testing**
Only tested on latest Firefox, not had a chance to test on other browsers.

Tested at 360px, 768px, 1080px and 1440px breakpoints.

**Existing behaviour**
![image](https://user-images.githubusercontent.com/35199256/136060458-19987575-272c-4ed0-b024-49549584dc30.png)

**After PR**
![image](https://user-images.githubusercontent.com/35199256/136060568-114cf981-a9b8-456b-8b11-9e5941accf9a.png)
